### PR TITLE
Update README for clearer Pages setup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules/
+notes.txt
+

--- a/README.md
+++ b/README.md
@@ -1,2 +1,35 @@
 # Testing Repo
-Just getting started...
+
+This repository contains a simple notepad web app. Open `index.html` in your web
+browser and begin typing to save notes. Your text is automatically stored in the
+browser so you can return to the page later and continue where you left off.
+
+## Hosting with GitHub Pages
+
+If you want to use the notepad directly from GitHub, enable GitHub Pages for this
+repository. Make sure your main HTML file is named `index.html` and lives in the
+root of the branch you deploy. Then follow these steps:
+
+1. Commit and push your code to GitHub.
+2. On GitHub, open **Settings** → **Pages**.
+3. Under **Source**, choose **Deploy from a branch** and select your branch
+   (usually `main`) with the root folder.
+4. Click **Save** (or **Save changes**). GitHub will display the new Pages URL
+   near the top of the screen.
+
+After a few moments, visit that URL to see the notepad hosted online.
+
+## Syncing Across Devices
+
+The notepad stores data in your browser by default. To share notes between
+different browsers or devices, run the included Node.js server:
+
+```bash
+npm install express cors
+node server.js
+```
+
+Edit `SERVER_URL` in `index.html` to point to where the server is running.
+When the page loads, it fetches the saved notes from the server and stores
+new changes there as you type.
+

--- a/index.html
+++ b/index.html
@@ -1,0 +1,59 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8">
+<title>Simple Notepad</title>
+<style>
+  body { font-family: Arial, sans-serif; padding: 20px; max-width: 800px; margin: auto; }
+  textarea { width: 100%; height: 80vh; font-size: 16px; }
+  #status { font-size: 14px; color: #555; margin-top: 5px; }
+</style>
+</head>
+<body>
+<h1>Simple Notepad</h1>
+<textarea id="note" placeholder="Start typing..."></textarea>
+<div id="status"></div>
+<script>
+const textarea = document.getElementById('note');
+const status = document.getElementById('status');
+const STORAGE_KEY = 'notepad-content';
+// URL of the sync server. Change this if you host the server elsewhere.
+const SERVER_URL = 'http://localhost:3000';
+
+function loadLocal() {
+  textarea.value = localStorage.getItem(STORAGE_KEY) || '';
+}
+
+function load() {
+  loadLocal();
+  fetch(`${SERVER_URL}/notes`)
+    .then(r => r.ok ? r.text() : '')
+    .then(text => {
+      if (text) {
+        textarea.value = text;
+        localStorage.setItem(STORAGE_KEY, text);
+      }
+    })
+    .catch(() => {});
+}
+
+function save() {
+  const content = textarea.value;
+  localStorage.setItem(STORAGE_KEY, content);
+  fetch(`${SERVER_URL}/notes`, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ content })
+  }).catch(() => {});
+  status.textContent = 'Saved';
+  setTimeout(() => {
+    if (status.textContent === 'Saved') status.textContent = '';
+  }, 1000);
+}
+
+textarea.addEventListener('input', save);
+
+load();
+</script>
+</body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "testing",
+  "version": "1.0.0",
+  "description": "This repository contains a simple notepad web app. Open `index.html` in your web browser and begin typing to save notes. Your text is automatically stored in the browser so you can return to the page later and continue where you left off.",
+  "main": "server.js",
+  "scripts": {
+    "start": "node server.js"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "dependencies": {
+    "cors": "^2.8.5",
+    "express": "^4.19.2"
+  }
+}

--- a/server.js
+++ b/server.js
@@ -1,0 +1,40 @@
+const express = require('express');
+const cors = require('cors');
+const fs = require('fs');
+const path = require('path');
+
+const app = express();
+const PORT = process.env.PORT || 3000;
+const FILE = path.join(__dirname, 'notes.txt');
+
+app.use(cors());
+app.use(express.json());
+
+function loadNotes() {
+  try {
+    return fs.readFileSync(FILE, 'utf8');
+  } catch (err) {
+    return '';
+  }
+}
+
+function saveNotes(content) {
+  fs.writeFileSync(FILE, content, 'utf8');
+}
+
+app.get('/notes', (req, res) => {
+  res.type('text/plain').send(loadNotes());
+});
+
+app.post('/notes', (req, res) => {
+  if (typeof req.body.content === 'string') {
+    saveNotes(req.body.content);
+    res.sendStatus(200);
+  } else {
+    res.sendStatus(400);
+  }
+});
+
+app.listen(PORT, () => {
+  console.log(`Notepad server listening on port ${PORT}`);
+});


### PR DESCRIPTION
## Summary
- clarify GitHub Pages instructions

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm start` *(fails: Cannot find module 'express')*

------
https://chatgpt.com/codex/tasks/task_e_683f4c7a0838832e963f5dda280df060