### PR TITLE
Fix stray markup in index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,9 +1,3 @@
-​:codex-file-citation[codex-file-citation]{line_range_start=1 line_range_end=67 path=README.md git_url="https://github.com/freakingjesus/Testing/blob/main/README.md#L1-L67"}​
-
----
-
-### `index.html`
-```html
 <!DOCTYPE html>
 <html lang="en">
 <head>


### PR DESCRIPTION
## Summary
- remove leftover Codex markup from the beginning of `index.html`

## Testing
- `npm install`
- `npm test` *(fails: loadNotes and saveNotes tests)*

------
https://chatgpt.com/codex/tasks/task_e_68431e36801c832e9083ca4663d4f4ea